### PR TITLE
add colorlog to install-requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=(
         'requests',
         'stellar-base',
+        'colorlog',
     ),
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=('test',)),


### PR DESCRIPTION
I modified install-requires in setup.py for a smooth installation.